### PR TITLE
Update setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ zip_safe = False
 include_package_data = True
 test_suite = tests
 install_requires =
-    django>=2.2,<4.1
+    django>=2.2
     django-appconf>=1.0.3
 
 [options.extras_require]


### PR DESCRIPTION
Remove <4.1 from Django dependency

<!--- django-opensearch -->
<!--- .github/PULL_REQUEST_TEMPLATE.md -->


<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove the dependency of Django being less than 4.1


## Motivation and Context
I am looking to upgrade to Django 4.2 and do not see any reason why this should be pinned to an older Django version

## How Has This Been Tested?

